### PR TITLE
Fixed checkbox type setting

### DIFF
--- a/src/Template/Admin/Settings/prefix.ctp
+++ b/src/Template/Admin/Settings/prefix.ctp
@@ -14,12 +14,25 @@ foreach ($settings as $id => $setting) {
     
     $name = explode('.', $setting->name);
     
-    echo $this->Form->input($id . '.value', [
-        'type' => (($setting->type) ? $setting->type : 'text'),
-        'label' => ucfirst(end($name)) . (($setting->description) ? ' - ' . $setting->description : ''),
-        'options' => (($setting->options) ? $setting->options_array : ''),
-        'value' => $setting->value,
-    ]);
+    switch($setting->type){
+        case 'checkbox':
+            echo $this->Form->input($id . '.value', [
+                'type' => (($setting->type) ? $setting->type : 'text'),
+                'label' => ucfirst(end($name)) . (($setting->description) ? ' - ' . $setting->description : ''),
+                'options' => (($setting->options) ? $setting->options : ''),
+                'value' => 1,
+                'checked' => $setting->value,
+            ]);
+            break;
+        default:
+            echo $this->Form->input($id . '.value', [
+                'type' => (($setting->type) ? $setting->type : 'text'),
+                'label' => ucfirst(end($name)) . (($setting->description) ? ' - ' . $setting->description : ''),
+                'options' => (($setting->options) ? $setting->options : ''),
+                'value' => $setting->value,
+            ]);
+            break;
+    }
 }
 
 echo $this->Form->button(__('Submit'));


### PR DESCRIPTION
I was trying to add an setting with checkbox type and realized that values are not recording in database.

Checkbox type example:

``` php
Setting::register('App.CheckboxOption', 1, ['editable'=>1, 'type'=>'checkbox', 'value'=>1]);
```

Added a switch statement to treat each field type individually, added checkbox field type and fixed a typo ($setting->options_array)
