### PR TITLE
Checkbox type in a setting

### DIFF
--- a/src/Template/Admin/Settings/prefix.ctp
+++ b/src/Template/Admin/Settings/prefix.ctp
@@ -14,12 +14,25 @@ foreach ($settings as $id => $setting) {
     
     $name = explode('.', $setting->name);
     
-    echo $this->Form->input($id . '.value', [
-        'type' => (($setting->type) ? $setting->type : 'text'),
-        'label' => ucfirst(end($name)) . (($setting->description) ? ' - ' . $setting->description : ''),
-        'options' => (($setting->options) ? $setting->options_array : ''),
-        'value' => $setting->value,
-    ]);
+    switch($setting->type){
+        case 'checkbox':
+            echo $this->Form->input($id . '.value', [
+                'type' => (($setting->type) ? $setting->type : 'text'),
+                'label' => ucfirst(end($name)) . (($setting->description) ? ' - ' . $setting->description : ''),
+                'options' => (($setting->options) ? $setting->options : ''),
+                'value' => 1,
+                'checked' => $setting->value,
+            ]);
+            break;
+        default:
+            echo $this->Form->input($id . '.value', [
+                'type' => (($setting->type) ? $setting->type : 'text'),
+                'label' => ucfirst(end($name)) . (($setting->description) ? ' - ' . $setting->description : ''),
+                'options' => (($setting->options) ? $setting->options : ''),
+                'value' => $setting->value,
+            ]);
+            break;
+    }
 }
 
 echo $this->Form->button(__('Submit'));

--- a/tests/TestCase/Controller/Admin/SettingsControllerTest.php
+++ b/tests/TestCase/Controller/Admin/SettingsControllerTest.php
@@ -88,7 +88,7 @@ class SettingsControllerTest extends IntegrationTestCase
         ]]);
 
         Setting::write('App.Key1', 'Value1');
-        Setting::write('App.Key2', 'Value2');
+        Setting::write('App.Key2', 1, ['editable'=>1, 'type'=>'checkbox', 'value'=>1]);
 
         Setting::write('CM.Key1', 'Value1');
         Setting::write('CM.Key2', 'Value2');
@@ -105,8 +105,8 @@ class SettingsControllerTest extends IntegrationTestCase
         $this->assertResponseContains('<div class="input text"><label for="0-value">Key1</label>');
         $this->assertResponseContains('<input type="text" name="0[value]" options="" id="0-value" value="Value1"></div>');
         $this->assertResponseContains('<input type="hidden" name="1[id]" id="1-id" value="2">');
-        $this->assertResponseContains('<div class="input text"><label for="1-value">Key2</label>');
-        $this->assertResponseContains('<input type="text" name="1[value]" options="" id="1-value" value="Value2"></div>');
+        $this->assertResponseContains('<div class="input checkbox"><input type="hidden" name="1[value]" value="0">');
+        $this->assertResponseContains('<label for="1-value"><input type="checkbox" name="1[value]" value="1" options="" checked="checked" id="1-value">Key2</label></div>');
         $this->assertResponseContains('<button type="submit">Submit</button></form>');
 
         $this->get('/admin/settings/settings/prefix/CM');

--- a/tests/TestCase/Controller/Admin/SettingsControllerTest.php
+++ b/tests/TestCase/Controller/Admin/SettingsControllerTest.php
@@ -88,7 +88,7 @@ class SettingsControllerTest extends IntegrationTestCase
         ]]);
 
         Setting::write('App.Key1', 'Value1');
-        Setting::write('App.Key2', 1, ['editable'=>1, 'type'=>'checkbox', 'value'=>1]);
+        Setting::write('App.Key2', 1, ['editable' => 1, 'type' => 'checkbox', 'value' => 1]);
 
         Setting::write('CM.Key1', 'Value1');
         Setting::write('CM.Key2', 'Value2');


### PR DESCRIPTION
I was trying to add an setting with checkbox type and realized that values are not recording in database.

Checkbox type example:

``` php
Setting::register('App.CheckboxOption', 1, ['editable'=>1, 'type'=>'checkbox', 'value'=>1]);
```

Added a switch statement to treat each field type individually, added checkbox field type and fixed a typo ($setting->options_array)

**Update**: Test added
