### PR TITLE
Updated to allow arrays.

### DIFF
--- a/src/Core/Setting.php
+++ b/src/Core/Setting.php
@@ -178,6 +178,10 @@ class Setting
             if ($options['overrule']) {
                 $data = $model->findByName($key)->first();
                 if ($data) {
+                    if(is_array($value) && !empty($value)) {
+                        $value = serialize($value);
+                    }
+                    
                     $data->set('value', $value);
                     $model->save($data);
                 } else {

--- a/src/Core/Setting.php
+++ b/src/Core/Setting.php
@@ -17,7 +17,6 @@ namespace Settings\Core;
 use Cake\Datasource\ConnectionManager;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
-use Cake\Core\Configure;
 
 class Setting
 {

--- a/src/Core/Setting.php
+++ b/src/Core/Setting.php
@@ -105,7 +105,7 @@ class Setting
                 {
                     if(self::_serialized($data_set->value))
                     {
-                        $data_set->value = @unserialize($data_set->value);
+                        $data_set->value = unserialize($data_set->value);
                     }
                     static::$_values = Hash::insert(static::$_values, $data_set->name, $data_set->value);
                 }
@@ -120,7 +120,7 @@ class Setting
 
         if(self::_serialized($data['value']))
         {
-            $data['value'] = @unserialize($data['value']);
+            $data['value'] = unserialize($data['value']);
         }
         self::_store($key, $data['value']);
 
@@ -173,15 +173,15 @@ class Setting
         $options = Hash::merge($_options, $options);
 
         $model = self::model();
+        
+        if(is_array($value) && !empty($value)) {
+            $value = serialize($value);
+        }        
 
         if (self::check($key)) {
             if ($options['overrule']) {
                 $data = $model->findByName($key)->first();
-                if ($data) {
-                    if(is_array($value) && !empty($value)) {
-                        $value = serialize($value);
-                    }
-                    
+                if ($data) {                    
                     $data->set('value', $value);
                     $model->save($data);
                 } else {
@@ -400,12 +400,12 @@ class Setting
     protected static function _serialized( $value, &$result = null ) {
 
         if ( ! is_string( $value ) ) {
-            return FALSE;
+            return false;
         }
 
         if ( 'b:0;' === $value ) {
-            $result = FALSE;
-            return TRUE;
+            $result = false;
+            return true;
         }
         $length	= strlen($value);
         $end	= '';
@@ -414,7 +414,7 @@ class Setting
             switch ($value[0]) {
                 case 's':
                     if ( '"' !== $value[$length - 2] )
-                        return FALSE;
+                        return false;
                     
                 case 'b':
                 case 'i':
@@ -426,7 +426,7 @@ class Setting
                     $end .= '}';
         
                     if ( ':' !== $value[1] )
-                        return FALSE;
+                        return false;
         
                     switch ( $value[2] ) {
                         case 0:
@@ -442,26 +442,26 @@ class Setting
                         break;
         
                         default:
-                            return FALSE;
+                            return false;
                     }
                 case 'N':
                     $end .= ';';
                 
                     if ( $value[$length - 1] !== $end[0] )
-                        return FALSE;
+                        return false;
                 break;
                 
                 default:
-                    return FALSE;
+                    return false;
             }
         }
         
-        if ( ( $result = @unserialize($value) ) === FALSE ) {
+        if ( ( $result = unserialize($value) ) === false ) {
             $result = null;
-            return FALSE;
+            return false;
         }
         
-        return TRUE;
+        return true;
     }
     
     

--- a/src/Core/Setting.php
+++ b/src/Core/Setting.php
@@ -91,9 +91,8 @@ class Setting
 
         if ($data->count() > 0) {
             $data = $data->first()->toArray();
-        }
-        else {
-            
+        } else {
+
             $data = $model->find()
                   ->select(['name', 'value'])
                   ->where(['name LIKE' =>  $key.'.%']);
@@ -103,8 +102,7 @@ class Setting
                 
                 foreach($data as $data_set)
                 {
-                    if(self::_serialized($data_set->value))
-                    {
+                    if(self::_serialized($data_set->value)) {
                         $data_set->value = unserialize($data_set->value);
                     }
                     static::$_values = Hash::insert(static::$_values, $data_set->name, $data_set->value);
@@ -112,14 +110,12 @@ class Setting
                 
                 $data['value'] = static::$_values;
             }
-            else
-            {
+            else {
                 return null;
             }
         }
 
-        if(self::_serialized($data['value']))
-        {
+        if(self::_serialized($data['value'])) {
             $data['value'] = unserialize($data['value']);
         }
         self::_store($key, $data['value']);

--- a/src/Core/Setting.php
+++ b/src/Core/Setting.php
@@ -416,7 +416,7 @@ class Setting
                 case 'b':
                 case 'i':
                 case 'd':
-                    // This looks odd but it is quicker than isset()ing
+                    
                     $end .= ';';
                 case 'a':
                 case 'O':

--- a/tests/TestCase/Core/SettingTest.php
+++ b/tests/TestCase/Core/SettingTest.php
@@ -148,6 +148,17 @@ class SettingTest extends TestCase
         $this->assertEquals(1, Setting::read('App.UniqueReadvalue'));
         $this->assertEquals(1, Setting::read('App.UniqueReadvalue', 'integer'));
         $this->assertEquals('1', Setting::read('App.UniqueReadvalue', 'string'));
+        
+        $data = [
+            'name' => 'App.UniqueArray',
+            'value' => 'a:4:{i:0;i:1;i:2;i:3;i:3;s:3:"one";s:3:"two";s:5:"three";}'
+        ];
+
+        $this->Settings->save($this->Settings->newEntity($data));
+        $read = Setting::read('App.UniqueArray');
+        $this->assertGreaterThan(0, count($read));
+        $this->assertEquals([1,2=>3,'one','two'=>'three'], Setting::read('App.UniqueArray'));
+        
     }
 
     /**
@@ -197,6 +208,31 @@ class SettingTest extends TestCase
         $this->assertEquals(1, $value->editable);
         $this->assertEquals(20, $value->weight);
         $this->assertEquals(1, $value->autoload);
+        
+        Setting::write('App.WriteArray',[1,2=>3,'one','two'=>'three'],[
+            'description' => 'Short description',
+            'type' => 'array',
+            'editable' => true,
+            'options' => [
+                1 => 'One',
+                2 => 'Two'
+            ],
+            'weight' => 20,
+            'autoload' => true,
+        ]);        
+        
+        $this->assertEquals(3, $this->Settings->find('all')->count());
+
+        $value = $this->Settings->get(3);        
+        $this->assertEquals('App.WriteArray', $value->name);
+        $this->assertEquals('App.WriteArray', $value->key);        
+        $this->assertEquals('a:4:{i:0;i:1;i:2;i:3;i:3;s:3:"one";s:3:"two";s:5:"three";}', $value->value);
+        $this->assertEquals('Short description', $value->description);
+        $this->assertEquals('array', $value->type);
+        $this->assertEquals(1, $value->editable);
+        $this->assertEquals(20, $value->weight);
+        $this->assertEquals(1, $value->autoload);        
+        
     }
 
     /**


### PR DESCRIPTION
Hopefully useful but the idea of this pull request was to allow arrays to be added and inserted in similar format to that of Configure::write/read. 

Example when using an array name such as: name.anothername and so on:-
![pullrequest](https://cloud.githubusercontent.com/assets/14294908/10517759/441f5fbe-7356-11e5-8982-e0d2b375be8a.PNG)
