### PR TITLE
Set type of editable and autoload to boolean

### DIFF
--- a/config/Migrations/20150126111319_settings_initial.php
+++ b/config/Migrations/20150126111319_settings_initial.php
@@ -39,17 +39,17 @@ class SettingsInitial extends AbstractMigration
                 'limit'   => '50',
                 'default' => '',
             ])
-            ->addColumn('editable', 'integer', [
-                'limit'   => '11',
-                'default' => '1',
+            ->addColumn('editable', 'boolean', [
+                'limit'   => '1',
+                'default' => true,
             ])
             ->addColumn('weight', 'integer', [
                 'limit'   => '11',
                 'default' => '0',
             ])
-            ->addColumn('autoload', 'integer', [
-                'limit'   => '11',
-                'default' => '1',
+            ->addColumn('autoload', 'boolean', [
+                'limit'   => '1',
+                'default' => true,
             ])
             ->addColumn('created', 'datetime')
             ->addColumn('modified', 'datetime')


### PR DESCRIPTION
Create boolean type for editable and autoload field to prevent "cannot be null" errors when using something like `Setting::register('Google.ApiKey', 'abc', ['editable' => false]);`.
